### PR TITLE
Show the server name in the footer

### DIFF
--- a/reddit_gold/__init__.py
+++ b/reddit_gold/__init__.py
@@ -1,9 +1,16 @@
+from r2.lib.configparse import ConfigValue
 from r2.lib.js import Module
 from r2.lib.plugin import Plugin
 
 
 class Gold(Plugin):
     needs_static_build = True
+
+    config = {
+        ConfigValue.str: [
+            "gold_hostname_file",
+        ],
+    }
 
     js = {
         'gold': Module('gold.js',
@@ -19,3 +26,6 @@ class Gold(Plugin):
 
     def load_controllers(self):
         from reddit_gold.controllers import GoldController, GoldApiController
+
+        from reddit_gold.server_naming import hooks
+        hooks.register_all()

--- a/reddit_gold/server_naming.py
+++ b/reddit_gold/server_naming.py
@@ -1,0 +1,18 @@
+from pylons import g, c
+
+from r2.lib.hooks import HookRegistrar
+
+
+hooks = HookRegistrar()
+
+
+@hooks.on("reddit.request.begin")
+def add_gold_hostname():
+    c.gold_hostname = ""
+
+    if g.gold_hostname_file:
+        try:
+            with open(g.gold_hostname_file) as f:
+                c.gold_hostname = f.read().strip()
+        except IOError:
+            pass

--- a/reddit_gold/templates/debugfooter.html
+++ b/reddit_gold/templates/debugfooter.html
@@ -1,0 +1,10 @@
+<p class="bottommenu debuginfo">
+  <span class="icon">&pi;</span>&nbsp;
+  <span class="content">Rendered by PID ${g.reddit_pid} on&#32;
+    % if c.gold_hostname:
+      <b class="buygold" title="${g.reddit_host}">${c.gold_hostname}</b>
+    % else:
+      ${g.reddit_host}
+    % endif
+    &#32;at ${c.start_time} running ${g.short_version}.</span>
+</p>


### PR DESCRIPTION
I'm not a huge fan of duplicating the footer text like this, but I think it's the best solution to not be putting way too much knowledge of specifically what we're overriding in public.

![forkface](https://f.cloud.github.com/assets/338853/1425157/9a3634ec-402f-11e3-9170-9268c7725f08.png)

(since the screenshot conveniently took my cursor away, it's hard to see that I'm hovering over the gold server name there to get that popup)
