### PR TITLE
Gold end-of-day: cast goal for float math

### DIFF
--- a/scripts/gold_end_of_day.py
+++ b/scripts/gold_end_of_day.py
@@ -57,7 +57,7 @@ def post_if_goal_reached(date):
 
     revenue = gold_revenue_on(date)
     goal = gold_goal_on(date)
-    percent = revenue / goal
+    percent = revenue / float(goal)
     bucket = int(percent)
     if bucket == 0:
         return


### PR DESCRIPTION
`gold_goal_on()` returns an int now, so this is causing percent to always be 100% in the posts it's used in.

:eyeglasses: @spladug 
