### PR TITLE
Nameaserver: only support asterisk italics syntax

### DIFF
--- a/scripts/gold_end_of_day.py
+++ b/scripts/gold_end_of_day.py
@@ -121,7 +121,7 @@ def activate_requested_names(but_not):
         activate_names_requested_in(link)
 
 
-valid_name_re = re.compile(r"(?:^|[_*])([A-Za-z0-9-]{1,25})(?:$|[_*])")
+valid_name_re = re.compile(r"(?:^|\*)([A-Za-z0-9-]{1,25})(?:$|\*)")
 def activate_names_requested_in(link):
     tree = get_comment_tree(link)
     acceptable_names = []


### PR DESCRIPTION
Supporting underscores has the potential to cause issues (and did on Jan 2), and the instructions specify to use asterisks anyway, so I think it's probably best to make that the only valid syntax for italicized names.

:eyeglasses: @spladug 
