### PR TITLE
Gold partners: add categories, support filtering

### DIFF
--- a/reddit_gold/models.py
+++ b/reddit_gold/models.py
@@ -53,9 +53,10 @@ class GoldPartner(WikiPageIniItem):
                  is_enabled=True, is_new=False, instructions=None,
                  discussion_id36=None, button_label=None, button_dest=None,
                  claim_dest=None, giveaway_desc=None, css_classes=None,
-                 **kwargs):
+                 category=None, **kwargs):
         self.id = id
         self.name = name
+        self.category = category
         self.about_page_desc = about_page_desc
         self.short_desc = short_desc
         self.url = url

--- a/reddit_gold/pages.py
+++ b/reddit_gold/pages.py
@@ -30,6 +30,7 @@ class GoldPartnersPage(BoringPage):
         }
 
         self.partners = GoldPartner.get_all()
+        self.categories = set()
         self.giveaways = []
 
         # batch-lookup the Links and Subreddits for discussions
@@ -39,6 +40,9 @@ class GoldPartnersPage(BoringPage):
                                      data=True)
 
         for partner in self.partners:
+            if partner.category:
+                self.categories.add(partner.category)
+
             extra_classes = partner.css_classes
             if partner.is_new:
                 extra_classes.append('new')
@@ -57,6 +61,8 @@ class GoldPartnersPage(BoringPage):
             else:
                 partner.discussion_url = None
                 partner.discussion_num_comments = None
+
+        self.categories = sorted(self.categories)
 
         if c.user_is_loggedin:
             self.existing_codes = GoldPartnerDealCode.get_codes_for_user(c.user)

--- a/reddit_gold/public/static/css/gold.less
+++ b/reddit_gold/public/static/css/gold.less
@@ -391,6 +391,10 @@ section#about-gold, section#about-gold-partners {
             ul li {
                 display: inline;
                 margin-left: 0.5em;
+
+                &.active {
+                    font-weight: bold;
+                }
             }
 
             ul li + li:before {

--- a/reddit_gold/public/static/css/gold.less
+++ b/reddit_gold/public/static/css/gold.less
@@ -377,6 +377,28 @@ section#about-gold, section#about-gold-partners {
             }
         }
 
+        &#category-nav {
+            line-height: 1em;
+            height: auto;
+            text-align: center;
+            font-size: 14px;
+
+            h1 {
+                font-size: 1.2em;
+                margin-bottom: 0.7em;
+            }
+
+            ul li {
+                display: inline;
+                margin-left: 0.5em;
+            }
+
+            ul li + li:before {
+                content: '|';
+                margin-right: 0.5em;
+            }
+        }
+
         &#partner-benefits {
             height: auto;
             line-height: inherit;

--- a/reddit_gold/public/static/js/gold/gold.js
+++ b/reddit_gold/public/static/js/gold/gold.js
@@ -4,8 +4,13 @@ r.gold = {
             $(this).select()
         })
 
-        $('section#category-nav a').on('click', function() {
+        $('#category-nav li').on('click', function(e) {
+          e.preventDefault()
+          e.stopPropagation()
           var category = $(this).text()
+
+          $('#category-nav li.active').removeClass('active')
+          $(this).addClass('active')
 
           if (category == "all") {
             $('section[data-category]').show()

--- a/reddit_gold/public/static/js/gold/gold.js
+++ b/reddit_gold/public/static/js/gold/gold.js
@@ -11,7 +11,7 @@ r.gold = {
             $('section[data-category]').show()
           } else {
             $('section[data-category]').hide()
-            $('section[data-category="'+category+'"]').show()
+            $('section[data-category="' + category + '"]').show()
           }
         })
     },

--- a/reddit_gold/public/static/js/gold/gold.js
+++ b/reddit_gold/public/static/js/gold/gold.js
@@ -3,6 +3,17 @@ r.gold = {
         $('section#about-gold-partners').on('click', 'input.code', function() {
             $(this).select()
         })
+
+        $('section#category-nav a').on('click', function() {
+          var category = $(this).text()
+
+          if (category == "all") {
+            $('section[data-category]').show()
+          } else {
+            $('section[data-category]').hide()
+            $('section[data-category="'+category+'"]').show()
+          }
+        })
     },
 
     claim_gold_partner_deal_code: function (elem, name, redirect_url) {

--- a/reddit_gold/templates/goldinfopage.html
+++ b/reddit_gold/templates/goldinfopage.html
@@ -11,8 +11,8 @@
   ${less_stylesheet('gold.less')}
 </%def>
 
-<%def name="feature_item(name, img_src, description_md, extra_class='', img_url=None)">
-  <section id="${name}" ${classes(extra_class)}>
+<%def name="feature_item(name, img_src, description_md, extra_class='', img_url=None, category='')">
+  <section id="${name}" ${classes(extra_class)} data-category="${category}">
     %if img_url:
       <a href="${img_url}">
     %endif

--- a/reddit_gold/templates/goldpartnerspage.html
+++ b/reddit_gold/templates/goldpartnerspage.html
@@ -62,9 +62,9 @@
   <section id="category-nav">
     <h1>filter partners by category</h1>
     <ul>
-      <li><a href="javascript:void(0)">all</a></li>
+      <li class="active"><a href="#">all</a></li>
     % for category in thing.categories:
-      <li><a href="javascript:void(0)">${category}</a></li>
+      <li><a href="#">${category}</a></li>
     % endfor
     </ul>
   </section>

--- a/reddit_gold/templates/goldpartnerspage.html
+++ b/reddit_gold/templates/goldpartnerspage.html
@@ -23,8 +23,8 @@
   ${less_stylesheet('gold.less')}
 </%def>
 
-<%def name="partner_item(name, how_to_use, img_src, img_url=None, description_md='', extra_class='', button_dest=None, button_label=None, claim_dest='', discussion_link=None, discussion_num_comments=None)">
-  <%call expr="feature_item(name, img_src, description_md, extra_class, img_url)">
+<%def name="partner_item(name, category, how_to_use, img_src, img_url=None, description_md='', extra_class='', button_dest=None, button_label=None, claim_dest='', discussion_link=None, discussion_num_comments=None)">
+  <%call expr="feature_item(name, img_src, description_md, extra_class, img_url, category)">
     %if c.user.gold:
       <div class="how-to-use">
         ${_md(how_to_use)}
@@ -59,8 +59,19 @@
       </div>
     </%call>
 
+  <section id="category-nav">
+    <h1>filter partners by category</h1>
+    <ul>
+      <li><a href="javascript:void(0)">all</a></li>
+    % for category in thing.categories:
+      <li><a href="javascript:void(0)">${category}</a></li>
+    % endfor
+    </ul>
+  </section>
+
   % for partner in thing.partners:
     ${partner_item(name=partner.id,
+                   category=partner.category,
                    how_to_use=partner.instructions,
                    img_src=partner.image_url,
                    img_url=partner.url,


### PR DESCRIPTION
Adds categories to the gold partners, and a filtering bar at the top of the partners page:

![partner-categories](https://cloud.githubusercontent.com/assets/9033/3557045/2609ffca-092b-11e4-80df-c27aad59db65.png)

:eyeglasses: @bsimpson63 @umbrae @powerlanguage
