### PR TITLE
Fix snoovatars

### DIFF
--- a/reddit_gold/public/static/css/gold.less
+++ b/reddit_gold/public/static/css/gold.less
@@ -732,7 +732,7 @@ section#postcard {
 
     .uses-icon(@filename, @width:70px, @height:70px) {
         .icon {
-            background: url(~'/static/snoovatar/icons/@{filename}.png') no-repeat center center;
+            background: url(~'../snoovatar/icons/@{filename}.png') no-repeat center center;
             width: @width;
             height: @height;
             background-size: @width @height;

--- a/reddit_gold/public/static/js/snoovatar/snoovatar.js
+++ b/reddit_gold/public/static/js/snoovatar/snoovatar.js
@@ -3,7 +3,7 @@
   var exports = r.snoovatar;
 
   // config values
-  var imagePath = r.utils.staticURL('snoovatar/images/');
+  var imagePath = '/static/snoovatar/images/';
   var filetype = 'png';
   var canvasSize = 400;
   var pixelRatio = 2;


### PR DESCRIPTION
Two issues.  First, none of the icons are loading on the snoovatar page, which was just an oversight.  The bigger issue is that the way the colorization feature works doesn't play nice with images loaded from a different domain.  Images loaded from a different domain _taint_ a canvas when drawn to it, preventing the use of the `getImageData` and `putImageData` methods.  Fixing that _correctly_ is going to take a little more time, but loading the images from reddit.com does fix the issue, and is probably fine for internal testing.

:eyeglasses: @umbrae @rram @xiongchiamiov
