### PR TITLE
Restructure gold info page

### DIFF
--- a/reddit_gold/models.py
+++ b/reddit_gold/models.py
@@ -32,13 +32,14 @@ class GoldFeature(WikiPageIniItem):
         return Frontpage, g.wiki_page_gold_features
 
     def __init__(self, id, name, description, image_url, is_enabled=True,
-                 is_new=False):
+                 is_new=False, is_top=False):
         self.id = id
         self.name = name
         self.description = description
         self.image_url = image_url
         self.is_enabled = is_enabled
         self.is_new = is_new
+        self.is_top = is_top
 
 
 class GoldPartnerCodesExhaustedError(Exception):
@@ -53,7 +54,7 @@ class GoldPartner(WikiPageIniItem):
         return Frontpage, g.wiki_page_gold_partners
 
     def __init__(self, id, name, about_page_desc, short_desc, url, image_url,
-                 is_enabled=True, is_new=False, instructions=None,
+                 is_enabled=True, is_new=False, is_top=False, instructions=None,
                  discussion_id36=None, button_label=None, button_dest=None,
                  claim_dest=None, giveaway_desc=None, css_classes=None,
                  category=None, **kwargs):
@@ -66,6 +67,7 @@ class GoldPartner(WikiPageIniItem):
         self.image_url = image_url
         self.is_enabled = is_enabled
         self.is_new = is_new
+        self.is_top = is_top
         self.instructions = instructions
         self.discussion_id36 = discussion_id36
         self.button_label = button_label

--- a/reddit_gold/pages.py
+++ b/reddit_gold/pages.py
@@ -12,14 +12,23 @@ class GoldInfoPage(BoringPage):
             "gold_month_price": g.gold_month_price,
             "gold_year_price": g.gold_year_price,
         }
+        self.top_features = []
+        self.other_features = []
+        self.top_partners = []
+
         all_features = GoldFeature.get_all()
         for feature in all_features:
             feature.extra_classes = 'new' if feature.is_new else ''
-        NUM_FEATURES_ABOVE_PARTNERS = 2
-        self.top_features = all_features[:NUM_FEATURES_ABOVE_PARTNERS]
-        self.other_features = all_features[NUM_FEATURES_ABOVE_PARTNERS:]
+            if feature.is_top:
+                self.top_features.append(feature)
+            else:
+                self.other_features.append(feature)
 
-        self.partners = GoldPartner.get_all()
+        all_partners = GoldPartner.get_all()
+        for partner in all_partners:
+            if partner.is_top:
+                self.top_partners.append(partner)
+
         BoringPage.__init__(self, *args, **kwargs)
 
 

--- a/reddit_gold/templates/goldinfopage.html
+++ b/reddit_gold/templates/goldinfopage.html
@@ -86,15 +86,17 @@
                      description_md='# {0}\n{1}'.format(feature.name, feature.description),
                      extra_class=feature.extra_classes)}
     % endfor
-                     
-    <section id="partner-benefits">
-        <h1>${_('Awesome stuff for gold members:')}</h1>
-        <ul>
-        % for partner in thing.partners:
-          <li>${partner_item(partner.id, partner.about_page_desc, partner.image_url)}</li>
-        % endfor
-        </ul>
-    </section>
+    % if len(thing.top_partners) > 0:
+      <section id="partner-benefits">
+          <h1>${_('Awesome stuff for gold members:')}</h1>
+          <ul>
+            % for partner in thing.top_partners:
+              <li>${partner_item(partner.id, partner.about_page_desc, partner.image_url)}</li>
+            % endfor
+          </ul>
+          <h1><br><a href="/gold/partners">${_('Check out the rest of our partners and deals!')}</a></h1>
+      </section>
+    % endif
 
     % for feature in thing.other_features:
       ${feature_item(name=feature.id,


### PR DESCRIPTION
:eyeglasses: @bsimpson63 

Create 'is_top' property for features and partners. Features with is_top=true in the gold_features wiki will be shown above the partners list. Any partners with is_top=true will be shown. A link to the remaining partners is shown after the top partners. The rest of the features in other_features will be shown below top_partners.

![gold partners](https://cloud.githubusercontent.com/assets/5882173/5288406/72016eb0-7ae9-11e4-9355-b8f7d17999f2.png)
