### PR TITLE
Remove tikkit terms.

### DIFF
--- a/reddit_gold/templates/goldpartnerspage.html
+++ b/reddit_gold/templates/goldpartnerspage.html
@@ -10,11 +10,6 @@
 
 <%def name="javascript_bottom()">
   ${parent.javascript_bottom()}
-  <script type="text/javascript">
-    if (window.location.hash == '#terms') {
-      $('#giveaway-rules').show()
-    }
-  </script>
   ${unsafe(js.use('gold'))}
 </%def>
 
@@ -84,48 +79,6 @@
                    extra_class=partner.extra_classes)}
   % endfor
 
-    <section id="terms" class="etc" style="border-top: none">
-      <a href="#terms" onclick="$('#giveaway-rules').toggle()">View official rules for "Golden Tikkit" giveaways</a>
-      <div id="giveaway-rules">
-        <h2>REDDIT</h2>
-        <h2>OFFICIAL GIVEAWAY RULES</h2>
-
-        <p>reddit and its partners will be giving away prizes to reddit gold members! Please read these rules carefully as they govern our prize giveaways. By entering a giveaway, you agree that these rules will apply to you.</p>
-
-        <h3>How to Enter</h3>
-        <p>You don't need to buy anything to enter a giveaway or to win a prize. All eligible reddit gold members may participate in the giveaway. For more information about reddit gold membership, please see&#32;<a href="/gold/about">http://www.reddit.com/gold/about/</a>. The dates of the giveaways will be listed in the prize details below.</p>
-
-        <h3>Other Ways to Enter</h3>
-        <p>You can become a reddit gold member for one month by mailing a postcard to reddit c/o Wired, 520 Third Street, San Francisco, CA 94107. For more information, see&#32;<a href="/gold/about#postcard">http://www.reddit.com/gold/about#postcard</a>.</p>
-
-        <h3>Prizes</h3>
-        <p>We will describe giveaway dates, prizes and their approximate retail value&#32;<a href="#prize-details" onclick="$('#prize-details').toggle()">here</a>. Your odds of winning depend on the number of reddit gold members - for example, if there are 10,000 reddit gold members, the odds of winning any one prize would be 1 in 10,000. reddit may substitute prizes of equal or greater value if we believe it is necessary.</p>
-
-        <div id="prize-details">
-          <h3>Prize Details</h3>
-          <ul>
-          % for giveaway in thing.giveaways:
-            <li>${giveaway}</li>
-          % endfor
-          </ul>
-        </div>
-
-        <h3>How to be Eligible for Giveaways</h3>
-        <p>In order to be eligible, you must be (1) a real person, (2) a registered member of reddit, (3) a legal resident of the United States, and (4) at least 18 years old at the time the prize is awarded. Only one entry is allowed per person per giveaway. Employees of reddit (or its partners) and their related family members are not eligible for giveaways. EACH GIVEAWAY IS VOID WHERE PROHIBITED OR RESTRICTED BY LAW and is subject to applicable federal, state and local laws and regulations.</p>
-
-        <h3>How We Select Prize Winners</h3>
-        <p>Winners will be randomly selected from all eligible reddit gold members. We'll contact you via your reddit mail account within 30 days if you have won. If you don't respond within 24 hours, or if you are not eligible to win a prize, or we cannot deliver the prize or prize notification to you, we may choose another winner. Winners may not substitute or transfer prizes. Winners are responsible for paying taxes on any prize, if applicable.</p>
-
-        <h3>Limitation of Liability</h3>
-        <p>reddit and our partners are not responsible for (1) your entries, (2) your use of any prize, (3) your participation in a giveaway, or (4) anything else outside of our reasonable control. reddit reserves the right to cancel or change any giveaway, prize, or entry if we believe the giveaway is not being properly conducted or any entries are fraudulent. If this happens, we will do our best to pick winners from all eligible, non-fraudulent entries. You hereby release reddit and its partners from all liability of any kind relating to any giveaway or any prize.</p>
-
-        <h3>Privacy and Legal</h3>
-        <p>To enter a giveaway, you may be required to give reddit and its partners certain information such as your name, physical address and redditgifts usernames. We will use this information in accordance with&#32;<a href="/help/privacypolicy">our Privacy Policy</a>. If one of our partners is awarding prizes, the giveaway will also be subject to their Privacy Policy and Terms of Use. All giveaways are governed by the laws of California and you agree that California courts will have jurisdiction over any disputes.</p>
-
-        <h3>Winners List</h3>
-        <p>After each giveaway ends, you can get a list of winners (including first name, last initial, city and state) by mailing a self-addressed stamped envelope with your request to reddit c/o Wired, 520 Third Street, San Francisco, CA 94107 within 90 days from when the giveaway ends.</p>
-      </div>
-    </section>
     ${goldinfo_footer()}
   </section>
 </%def>


### PR DESCRIPTION
:eyeglasses: @MelissaCole 

Removes the link to the now defunct golden tikkit giveaway terms.

This is a simple change, but I cannot test it on my instance.
